### PR TITLE
Fix typo inside permission.md

### DIFF
--- a/versions/unversioned/sdk/permissions.md
+++ b/versions/unversioned/sdk/permissions.md
@@ -60,7 +60,7 @@ async function checkMultiPermissions() {
   const { Permissions } = Expo;
   const { status, expires, permissions } = await Permissions.getAsync(Permissions.CALENDAR, Permissions.CONTACTS)
   if (status !== 'granted') {
-    alert('Hey! You heve not enabled selected permissions');
+    alert('Hey! You have not enabled selected permissions');
   }
 }
 ```


### PR DESCRIPTION
fix typo 'heve' to 'have'

<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
